### PR TITLE
Read `Authority` field in Cloudflare/Google DNS response

### DIFF
--- a/src/dns-resolvers.ts
+++ b/src/dns-resolvers.ts
@@ -28,7 +28,7 @@ export async function dnsRecordsCloudflare(name: string, type: string = 'A'): Pr
 	}
 
 	const json: any = await re.json()
-	const records: DnsRecord[] = (json.Answer || []).map((record: any) => {
+	const records: DnsRecord[] = (json.Answer || json.Authority || []).map((record: any) => {
 		const type = dnsTypeNumbers[record.type] || String(record.type)
 		let data = record.data
 
@@ -50,7 +50,7 @@ export async function dnsRecordsGoogle(name: string, type: string = 'A'): Promis
 	}
 
 	const json: any = await re.json()
-	const records: DnsRecord[] = (json.Answer || []).map((record: any) => {
+	const records: DnsRecord[] = (json.Answer || json.Authority || []).map((record: any) => {
 		const type = dnsTypeNumbers[record.type] || String(record.type)
 		let data = record.data
 


### PR DESCRIPTION
For some DNS queries, such as `type=NS` when `name=subdomain.example.com`, the response from Cloudflare/Google contains an `Authority` field instead of `Answer`.

This change reads the `Authority` field if present in order to fix a bug with `getAllDNSRecords("subdomain.example.com", { resolver: "cloudflare-dns" })`. Currently, instead of returning the records associated with the subdomain, it incorrectly returns an empty array because it does not read the `Authority` field in the NS records response. As a result, `nsRecords.length = 0` which fails the [`nsRecords.length` check here](https://github.com/LayeredStudio/dns-records/blob/main/src/index.ts#L200), and no requests for additional records are made.

```
curl --location 'https://dns.google/resolve?name=subdomain.example.com&type=NS&cd=1' \
--header 'accept: application/dns-json'

{
    "Status": 3,
    "TC": false,
    "RD": true,
    "RA": true,
    "AD": false,
    "CD": true,
    "Question": [
        {
            "name": "subdomain.example.com.",
            "type": 2
        }
    ],
    "Authority": [
        {
            "name": "example.com.",
            "type": 6,
            "TTL": 1800,
            "data": "ns.icann.org. noc.dns.icann.org. 2024041842 7200 3600 1209600 3600"
        }
    ],
    "Comment": "Response from 199.43.135.53."
}
```
